### PR TITLE
chore: .gitignore에서 사용하지 않는 항목 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,14 +53,12 @@ build/
 !**/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-gradle.properties
 
 ### Environment Variables ###
 # .env는 docker-compose 공통 설정으로 커밋됨
 # .env.local만 gitignore (민감 정보)
 .env.local
 .env.*.local
-.localstack-outputs.yml
 
 # Test results
 test-results/
@@ -80,7 +78,6 @@ Thumbs.db
 ehthumbs.db
 
 ### Docker ###
-docker-compose.override.yml
 .docker/
 
 ### LocalStack ###


### PR DESCRIPTION
- gradle.properties 제거 (Gradle dotenv 플러그인 사용)
- docker-compose.override.yml 제거 (더 이상 사용 안함)
- .localstack-outputs.yml 제거 (.env.local로 통합)